### PR TITLE
fix(backend): decouple core imports; make bleach optional

### DIFF
--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -1,53 +1,9 @@
 """
-Core Services Module
+Core package init kept lightweight on purpose.
 
-This module provides shared services and utilities for all tools in the Kyros Dashboard.
-It includes OpenAI client wrapper, logging, file handling, and other core functionality.
+Avoid importing heavy submodules at package import time to prevent optional
+dependencies (like the OpenAI SDK) from blocking unrelated imports. Modules
+should import the specific `core.*` subpackages they need directly.
 """
 
-from .openai_client import (
-    OpenAIClient,
-    OpenAIError,
-    get_openai_client,
-    create_openai_client,
-    VALID_MODELS,
-)
-from .logging import (
-    JobLogger,
-    StructuredLogger,
-    get_job_logger,
-    get_structured_logger,
-    log_api_request,
-    log_performance_metric,
-)
-from .file_handlers import (
-    FileHandler,
-    FileHandlerError,
-    FileHandlerManager,
-    get_file_handler_manager,
-    extract_text_from_file,
-    get_file_info,
-)
-
-__all__ = [
-    # OpenAI client
-    "OpenAIClient",
-    "OpenAIError",
-    "get_openai_client",
-    "create_openai_client",
-    "VALID_MODELS",
-    # Logging
-    "JobLogger",
-    "StructuredLogger",
-    "get_job_logger",
-    "get_structured_logger",
-    "log_api_request",
-    "log_performance_metric",
-    # File handlers
-    "FileHandler",
-    "FileHandlerError",
-    "FileHandlerManager",
-    "get_file_handler_manager",
-    "extract_text_from_file",
-    "get_file_info",
-]
+# Intentionally no eager imports here.


### PR DESCRIPTION
This PR keeps core package init lightweight and makes bleach optional in input validation to avoid import-time failures in CI.\n\n- core/__init__.py: remove eager imports to avoid heavy optional deps\n- core/input_validation.py: handle missing bleach with safe fallback sanitizer\n\nLocally: 153 backend tests passing. Intention is to stabilize develop CI post-merge.