### PR TITLE
Enable manual dispatch for plan-import

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows: ["Tests"]
     types: [completed]
+  workflow_dispatch: {}          # ← REQUIRED for manual runs
 
 env:
   NODE_VERSION: '20'

--- a/.github/workflows/mcp-tests.yml
+++ b/.github/workflows/mcp-tests.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - 'mcp/**'
       - '.github/workflows/mcp-tests.yml'
+  workflow_dispatch: {}          # ← REQUIRED for manual runs
 
 jobs:
   mcp-tests:

--- a/.github/workflows/plan-import.yml
+++ b/.github/workflows/plan-import.yml
@@ -28,38 +28,38 @@ jobs:
           PLANS_INBOX_FOLDER_ID: ${{ secrets.PLANS_INBOX_FOLDER_ID }}
         run: |
           python - <<'PY'
-import os, io, json, sys
-from google.oauth2 import service_account
-from googleapiclient.discovery import build
-from googleapiclient.http import MediaIoBaseDownload
-
-creds = service_account.Credentials.from_service_account_info(
-    json.loads(os.environ["GDRIVE_SA_JSON"]),
-    scopes=["https://www.googleapis.com/auth/drive.readonly"]
-)
-svc = build('drive', 'v3', credentials=creds)
-folder = os.environ["PLANS_INBOX_FOLDER_ID"]
-
-resp = svc.files().list(
-    q=f"'{folder}' in parents and trashed=false and name contains '.yml'",
-    orderBy="modifiedTime desc",
-    pageSize=1,
-    fields="files(id,name)"
-).execute()
-files = resp.get('files', [])
-if not files:
-    print("No .yml plans found in Plans Inbox."); sys.exit(1)
-fid, name = files[0]['id'], files[0]['name']
-
-request = svc.files().get_media(fileId=fid)
-fh = io.BytesIO()
-downloader = MediaIoBaseDownload(fh, request)
-done=False
-while not done:
-    status, done = downloader.next_chunk()
-open('planspec.yml', 'wb').write(fh.getvalue())
-print(f"DOWNLOADED {name} {fid}")
-PY
+          import os, io, json, sys
+          from google.oauth2 import service_account
+          from googleapiclient.discovery import build
+          from googleapiclient.http import MediaIoBaseDownload
+          
+          creds = service_account.Credentials.from_service_account_info(
+              json.loads(os.environ["GDRIVE_SA_JSON"]),
+              scopes=["https://www.googleapis.com/auth/drive.readonly"]
+          )
+          svc = build('drive', 'v3', credentials=creds)
+          folder = os.environ["PLANS_INBOX_FOLDER_ID"]
+          
+          resp = svc.files().list(
+              q=f"'{folder}' in parents and trashed=false and name contains '.yml'",
+              orderBy="modifiedTime desc",
+              pageSize=1,
+              fields="files(id,name)"
+          ).execute()
+          files = resp.get('files', [])
+          if not files:
+              print("No .yml plans found in Plans Inbox."); sys.exit(1)
+          fid, name = files[0]['id'], files[0]['name']
+          
+          request = svc.files().get_media(fileId=fid)
+          fh = io.BytesIO()
+          downloader = MediaIoBaseDownload(fh, request)
+          done=False
+          while not done:
+              status, done = downloader.next_chunk()
+          open('planspec.yml', 'wb').write(fh.getvalue())
+          print(f"DOWNLOADED {name} {fid}")
+          PY
 
       - name: Stage PlanSpec into repo
         run: |

--- a/.github/workflows/plan-import.yml
+++ b/.github/workflows/plan-import.yml
@@ -1,13 +1,12 @@
+# .github/workflows/plan-import.yml
+name: Import Latest Plan from Drive
+on:
+  workflow_dispatch: {}          # ← REQUIRED for manual runs
+  # (you can add other triggers later if you want)
+
 permissions:
   contents: write
   pull-requests: write
-name: Import Latest Plan from Drive
-on:
-  workflow_dispatch: {}   # run manually (or via gh workflow run)
-
-permissions:
-  contents: write          # commit plan & tasks
-  pull-requests: write     # open draft PR
 
 jobs:
   import:

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -13,6 +13,7 @@ on:
       - '**/*.md'
       - 'collaboration/logs/**'
       - 'CHANGELOG.md'
+  workflow_dispatch: {}          # ← REQUIRED for manual runs
 
 env:
   NODE_VERSION: '18'

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -5,6 +5,7 @@ on:
     branches: [develop, feature/*]
   pull_request:
     branches: [develop]
+  workflow_dispatch: {}          # ← REQUIRED for manual runs
 
 env:
   NODE_VERSION: '20'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ on:
       - 'docs/**'
       - 'collaboration/logs/**'
       - 'CHANGELOG.md'
+  workflow_dispatch: {}          # ← REQUIRED for manual runs
 
 concurrency:
   group: tests-${{ github.ref }}


### PR DESCRIPTION
Adds workflow_dispatch so we can run the importer from CLI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - CI workflows now support manual triggering from the UI.
- Documentation
  - Clarified comments explaining manual run requirements and future trigger options.
- Style
  - Improved formatting and removed inline permission comments for readability.
- Chores
  - No changes to workflow logic or job behavior; no user-facing impact on execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->