### PR TITLE
Collab Guard: enforce develop base + up-to-date check

### DIFF
--- a/.github/workflows/collab-guard.yml
+++ b/.github/workflows/collab-guard.yml
@@ -11,9 +11,14 @@ jobs:
       # Enforce develop as PR base branch
       - name: Check PR base branch
         run: |
+          # Allow release sync PRs: develop -> main
+          if [ "${{ github.base_ref }}" = "main" ] && [ "${{ github.head_ref }}" = "develop" ]; then
+            echo "✅ Release sync PR from 'develop' to 'main' allowed"
+            exit 0
+          fi
           if [ "${{ github.base_ref }}" != "develop" ]; then
             echo "❌ PRs must target 'develop' branch, not '${{ github.base_ref }}'"
-            echo "Please update your PR to target the 'develop' branch."
+            echo "If this is a release, open PR from 'develop' to 'main' only."
             exit 1
           else
             echo "✅ PR correctly targets 'develop' branch"

--- a/.github/workflows/collab-guard.yml
+++ b/.github/workflows/collab-guard.yml
@@ -5,6 +5,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need full history for branch comparisons
+
+      # Enforce develop as PR base branch
+      - name: Check PR base branch
+        run: |
+          if [ "${{ github.base_ref }}" != "develop" ]; then
+            echo "❌ PRs must target 'develop' branch, not '${{ github.base_ref }}'"
+            echo "Please update your PR to target the 'develop' branch."
+            exit 1
+          else
+            echo "✅ PR correctly targets 'develop' branch"
+          fi
+
+      # Ensure PR branch is up-to-date with base (develop)
+      - name: Check branch is up-to-date with base
+        run: |
+          git fetch origin "${{ github.base_ref }}:${{ github.base_ref }}"
+          BEHIND=$(git rev-list --left-right --count "${{ github.base_ref }}...${{ github.sha }}" | awk '{print $1}')
+          echo "Commits behind base '${{ github.base_ref }}': ${BEHIND:-0}"
+          if [ "${BEHIND:-0}" -gt 0 ]; then
+            echo "❌ Branch is behind '${{ github.base_ref }}' by ${BEHIND} commits."
+            echo "Please click 'Update branch' (preferred) or rebase onto '${{ github.base_ref }}'."
+            exit 1
+          else
+            echo "✅ Branch is up-to-date with base"
+          fi
       - name: No conflict markers
         run: |
           ! grep -R --line-number -E '^(<<<<<<<|=======|>>>>>>>)' . --exclude-dir=venv --exclude-dir=.venv --exclude-dir=node_modules || \


### PR DESCRIPTION
Adds explicit base-branch guard (must target develop) and fails PRs that are behind the base with clear guidance to Update branch or rebase.