### PR TITLE
CI: fix poetry install with --no-root (tests + quality-checks)

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -45,7 +45,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install poetry detect-secrets
           cd backend
-          poetry install --no-interaction --no-ansi
+          poetry install --no-interaction --no-ansi --no-root
 
       - name: Install Node.js dependencies
         run: |
@@ -99,7 +99,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install poetry
           cd backend
-          poetry install --no-interaction --no-ansi
+          poetry install --no-interaction --no-ansi --no-root
 
       - name: Install Node.js dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install poetry
-        poetry install --no-interaction --no-ansi
+        poetry install --no-interaction --no-ansi --no-root
 
     - name: Lint with ruff
       working-directory: ./backend
@@ -186,7 +186,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install poetry
-        poetry install --no-interaction --no-ansi
+        poetry install --no-interaction --no-ansi --no-root
         poetry run pip install ruff black bandit isort flake8
 
     - name: Install Node.js dependencies
@@ -298,7 +298,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install poetry
-        poetry install --no-interaction --no-ansi
+        poetry install --no-interaction --no-ansi --no-root
         poetry run pip install bandit
 
     - name: Run security scan with bandit


### PR DESCRIPTION
Poetry install fails with 'No file/folder found for package backend'. This repo is not packaged as an installable project.\n\n- Add --no-root to poetry install in Tests (backend-tests, e2e, security-scan)\n- Add --no-root to poetry install in Quality Checks (security, linting)\n\nThis unblocks backend-tests and build-verification by completing dependency installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CI dependency installation to skip installing the root package, improving environment isolation and consistency across linting, security checks, tests, build verification, and end-to-end workflows.
- Tests
  - Adjusted test pipeline dependency installation to reduce side effects and ensure more predictable runs.
- Security
  - Improved reliability of security-related checks by refining how dependencies are installed in the CI environment.
- Documentation
  - No user-facing documentation changes.
- Bug Fixes
  - No user-facing bug fixes included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->