### PR TITLE
CI: gate staging deploy to push on develop only

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -2,8 +2,6 @@ name: Deploy to Staging
 
 on:
   push:
-    branches: [develop, feature/*]
-  pull_request:
     branches: [develop]
 
 env:
@@ -13,6 +11,8 @@ env:
 jobs:
   # Deploy to staging environment
   deploy-staging:
+    # Run only on push to develop. Prevents PR runs without secrets.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Removes pull_request trigger and gates job to push on 'develop'. Prevents 'Deploy to Staging' check from failing on PRs without secrets. Production release flow unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated staging deployment triggers to run only on direct pushes to the develop branch; pull request events no longer initiate staging runs.
  - Added an extra safeguard so the staging job executes exclusively when the event is a push to develop.
  - No changes to deployment steps, environment, or credentials.
  - User-facing functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->