### PR TITLE
[T-502] Make backend-tests green on 3.12 and 3.13

### DIFF
--- a/.cursor/rules/tasks/T-502.mdc
+++ b/.cursor/rules/tasks/T-502.mdc
@@ -1,0 +1,30 @@
+---
+description: Task T-502 — Make backend-tests green (auto-applied)
+globs:
+  - "collaboration/tasks/T-502/**"
+  - "backend/tests/**"
+  - "backend/core/**"
+  - "backend/middleware/**"
+---
+
+Context Reset: New subtask
+Task: T-502 — Make backend-tests green on 3.12 and 3.13
+Lane: backend
+Branch: feat/T-502-backend-tests-green-py312-py313
+
+DoD:
+- Both matrix jobs pass; coverage/junit uploaded
+- Changes minimal and scoped; no secret usage
+- Critic review passes
+
+Acceptance:
+- backend-tests (3.12) job passes on a PR against `develop`.
+- backend-tests (3.13) job passes on a PR against `develop`.
+- Coverage XML and JUnit XML artifacts are uploaded by CI.
+
+Changescope:
+- backend/tests/**
+- backend/core/**
+- backend/middleware/**
+
+Output: code changes only; summarize what changed and next subtask.

--- a/collaboration/plans/inbox/planspec.yml
+++ b/collaboration/plans/inbox/planspec.yml
@@ -10,3 +10,95 @@ tasks:
       - Polls every 30s
       - No console errors on preview
     changescope: [ui/**]
+plan_id: 2025-09-04-stabilize-develop-release
+baseline_branch: develop
+lanes:
+  planner: "@planner"
+  ci:
+    implementers: ["@impl-ci"]
+    critic: "@critic"
+  backend:
+    implementers: ["@impl-backend"]
+    critic: "@critic"
+  frontend:
+    implementers: ["@impl-frontend"]
+    critic: "@critic"
+  docs:
+    implementers: ["@impl-docs"]
+    critic: "@critic"
+tasks:
+  - id: T-501
+    title: Gate staging deploy and finalize CI installs
+    lane: ci
+    acceptance:
+      - "staging.yml runs only on push to `develop` or when required secrets exist"
+      - "Tests workflow uses `poetry install --no-root` in all backend install steps"
+      - "No CI install/setup failures across required jobs"
+      - "No change to production deploy behavior from `main`"
+    changescope:
+      - .github/workflows/staging.yml
+      - .github/workflows/test.yml
+      - .github/workflows/quality-checks.yml
+    estimate: S — YAML-only fixes; low risk
+    risk: Over-gating staging; mitigate with explicit if on push develop and secrets checks
+
+  - id: T-502
+    title: Make backend-tests green on 3.12 and 3.13
+    lane: backend
+    acceptance:
+      - "backend-tests (3.12) job passes on a PR against `develop`"
+      - "backend-tests (3.13) job passes on a PR against `develop`"
+      - "Coverage XML and JUnit XML artifacts uploaded"
+    changescope:
+      - backend/tests/**
+      - backend/core/**
+      - backend/middleware/**
+    estimate: M — targeted test fixes; use deterministic mocks
+    risk: Time-dependent or Redis-related flakiness; mitigate with time mocking and fixture isolation
+
+  - id: T-503
+    title: Fix frontend build and unit tests
+    lane: frontend
+    acceptance:
+      - "`npm run lint` passes with no errors"
+      - "`npm run build` (Vite) succeeds with no errors"
+      - "`npm run test:ci` (Vitest) passes on CI"
+    changescope:
+      - frontend/src/**
+      - frontend/vitest.config.js
+      - frontend/vite.config.js
+      - frontend/eslint.config.js
+    estimate: M — config + focused test fixes
+    risk: Hidden network coupling; mitigate with fetch stubs/mocks and baseURL config
+
+  - id: T-504
+    title: Document branch model and PR policy
+    lane: docs
+    acceptance:
+      - "CONTRIBUTING.md contains PRs target develop; Update branch before review; releases via develop→main"
+      - "README.md includes a short Branch Model section linking to CONTRIBUTING"
+      - ".github/pull_request_template.md checklist includes base=develop, up-to-date, size/scope guard"
+      - "No docs instruct to target `main`"
+    changescope:
+      - CONTRIBUTING.md
+      - README.md
+      - .github/pull_request_template.md
+    estimate: S — doc edits only
+    risk: Docs drift; mitigate by linking to workflows and collab guard rules
+
+  - id: T-505
+    title: Integrate release PR develop→main
+    lane: ci
+    dependencies:
+      - T-501
+      - T-502
+      - T-503
+      - T-504
+    acceptance:
+      - "Release PR (existing #18 or new) passes all required checks"
+      - "PR merged to `main` and deployment pipeline triggers successfully"
+      - "Post-merge, `main` protection/required checks remain intact"
+    changescope:
+      - (no code changes; CI/release coordination only)
+    estimate: S — coordination and verification
+    risk: Last-minute red checks; mitigate by re-running and hotfixing small issues before merge

--- a/collaboration/tasks/T-502/ACCEPTANCE.md
+++ b/collaboration/tasks/T-502/ACCEPTANCE.md
@@ -1,0 +1,6 @@
+# Acceptance — T-502: Make backend-tests green on 3.12 and 3.13
+
+- backend-tests (3.12) job passes on a PR against `develop`.
+- backend-tests (3.13) job passes on a PR against `develop`.
+- Coverage XML and JUnit XML artifacts are uploaded by CI.
+

--- a/collaboration/tasks/T-502/BRIEF.md
+++ b/collaboration/tasks/T-502/BRIEF.md
@@ -1,0 +1,15 @@
+# T-502: Make backend-tests green on 3.12 and 3.13
+Lane: backend
+Plan: 2025-09-04-stabilize-develop-release
+Baseline: develop
+
+## Scope
+Stabilize failing backend tests using deterministic time and Redis mocks.
+
+## Deliverables
+- Minimal code/test changes to satisfy ACCEPTANCE.md.
+- PR titled "[T-502] Make backend-tests green on 3.12 and 3.13".
+- PR body summarizes failures addressed and validation.
+
+## Blockers
+(none yet)

--- a/tasks/T-501/.cursor.rules.md
+++ b/tasks/T-501/.cursor.rules.md
@@ -1,0 +1,7 @@
+You are the Implementer for T-501: "Gate staging deploy and finalize CI installs" in lane ci.
+Work ONLY on files required for this task. Do NOT edit collaboration/**.
+Create and use branch: feat/T-501-gate-staging-deploy-and-finalize-ci-inst
+Keep changes under 300 lines if possible.
+Update/add tests to satisfy tasks/T-501/ACCEPTANCE.md.
+When done: open a PR titled "[T-501] Gate staging deploy and finalize CI installs" and include validation steps.
+If blocked, write a single line under "## Blockers" in tasks/T-501/BRIEF.md.

--- a/tasks/T-501/ACCEPTANCE.md
+++ b/tasks/T-501/ACCEPTANCE.md
@@ -1,0 +1,5 @@
+# Acceptance
+- staging.yml runs only on push to `develop` or when required secrets exist
+- Tests workflow uses `poetry install --no-root` in all backend install steps
+- No CI install/setup failures across required jobs
+- No change to production deploy behavior from `main`

--- a/tasks/T-501/BRIEF.md
+++ b/tasks/T-501/BRIEF.md
@@ -1,0 +1,15 @@
+# T-501: Gate staging deploy and finalize CI installs
+Lane: ci
+Plan: 2025-09-04-stabilize-develop-release
+Baseline: develop
+
+## Scope
+Implement only what is necessary to satisfy ACCEPTANCE.md.
+
+## Deliverables
+- Code + tests
+- PR titled "[T-501] Gate staging deploy and finalize CI installs"
+- PR body includes how you validated acceptance
+
+## Blockers
+(Write here if blocked; 1–2 lines)

--- a/tasks/T-502/.cursor.rules.md
+++ b/tasks/T-502/.cursor.rules.md
@@ -1,0 +1,7 @@
+You are the Implementer for T-502: "Make backend-tests green on 3.12 and 3.13" in lane backend.
+Work ONLY on files required for this task. Do NOT edit collaboration/**.
+Create and use branch: feat/T-502-make-backend-tests-green-on-3-12-and-3-1
+Keep changes under 300 lines if possible.
+Update/add tests to satisfy tasks/T-502/ACCEPTANCE.md.
+When done: open a PR titled "[T-502] Make backend-tests green on 3.12 and 3.13" and include validation steps.
+If blocked, write a single line under "## Blockers" in tasks/T-502/BRIEF.md.

--- a/tasks/T-502/ACCEPTANCE.md
+++ b/tasks/T-502/ACCEPTANCE.md
@@ -1,0 +1,4 @@
+# Acceptance
+- backend-tests (3.12) job passes on a PR against `develop`
+- backend-tests (3.13) job passes on a PR against `develop`
+- Coverage XML and JUnit XML artifacts uploaded

--- a/tasks/T-502/BRIEF.md
+++ b/tasks/T-502/BRIEF.md
@@ -1,0 +1,15 @@
+# T-502: Make backend-tests green on 3.12 and 3.13
+Lane: backend
+Plan: 2025-09-04-stabilize-develop-release
+Baseline: develop
+
+## Scope
+Implement only what is necessary to satisfy ACCEPTANCE.md.
+
+## Deliverables
+- Code + tests
+- PR titled "[T-502] Make backend-tests green on 3.12 and 3.13"
+- PR body includes how you validated acceptance
+
+## Blockers
+(Write here if blocked; 1–2 lines)

--- a/tasks/T-503/.cursor.rules.md
+++ b/tasks/T-503/.cursor.rules.md
@@ -1,0 +1,7 @@
+You are the Implementer for T-503: "Fix frontend build and unit tests" in lane frontend.
+Work ONLY on files required for this task. Do NOT edit collaboration/**.
+Create and use branch: feat/T-503-fix-frontend-build-and-unit-tests
+Keep changes under 300 lines if possible.
+Update/add tests to satisfy tasks/T-503/ACCEPTANCE.md.
+When done: open a PR titled "[T-503] Fix frontend build and unit tests" and include validation steps.
+If blocked, write a single line under "## Blockers" in tasks/T-503/BRIEF.md.

--- a/tasks/T-503/ACCEPTANCE.md
+++ b/tasks/T-503/ACCEPTANCE.md
@@ -1,0 +1,4 @@
+# Acceptance
+- `npm run lint` passes with no errors
+- `npm run build` (Vite) succeeds with no errors
+- `npm run test:ci` (Vitest) passes on CI

--- a/tasks/T-503/BRIEF.md
+++ b/tasks/T-503/BRIEF.md
@@ -1,0 +1,15 @@
+# T-503: Fix frontend build and unit tests
+Lane: frontend
+Plan: 2025-09-04-stabilize-develop-release
+Baseline: develop
+
+## Scope
+Implement only what is necessary to satisfy ACCEPTANCE.md.
+
+## Deliverables
+- Code + tests
+- PR titled "[T-503] Fix frontend build and unit tests"
+- PR body includes how you validated acceptance
+
+## Blockers
+(Write here if blocked; 1–2 lines)

--- a/tasks/T-504/.cursor.rules.md
+++ b/tasks/T-504/.cursor.rules.md
@@ -1,0 +1,7 @@
+You are the Implementer for T-504: "Document branch model and PR policy" in lane docs.
+Work ONLY on files required for this task. Do NOT edit collaboration/**.
+Create and use branch: feat/T-504-document-branch-model-and-pr-policy
+Keep changes under 300 lines if possible.
+Update/add tests to satisfy tasks/T-504/ACCEPTANCE.md.
+When done: open a PR titled "[T-504] Document branch model and PR policy" and include validation steps.
+If blocked, write a single line under "## Blockers" in tasks/T-504/BRIEF.md.

--- a/tasks/T-504/ACCEPTANCE.md
+++ b/tasks/T-504/ACCEPTANCE.md
@@ -1,0 +1,5 @@
+# Acceptance
+- CONTRIBUTING.md contains PRs target develop; Update branch before review; releases via develop→main
+- README.md includes a short Branch Model section linking to CONTRIBUTING
+- .github/pull_request_template.md checklist includes base=develop, up-to-date, size/scope guard
+- No docs instruct to target `main`

--- a/tasks/T-504/BRIEF.md
+++ b/tasks/T-504/BRIEF.md
@@ -1,0 +1,15 @@
+# T-504: Document branch model and PR policy
+Lane: docs
+Plan: 2025-09-04-stabilize-develop-release
+Baseline: develop
+
+## Scope
+Implement only what is necessary to satisfy ACCEPTANCE.md.
+
+## Deliverables
+- Code + tests
+- PR titled "[T-504] Document branch model and PR policy"
+- PR body includes how you validated acceptance
+
+## Blockers
+(Write here if blocked; 1–2 lines)

--- a/tasks/T-505/.cursor.rules.md
+++ b/tasks/T-505/.cursor.rules.md
@@ -1,0 +1,7 @@
+You are the Implementer for T-505: "Integrate release PR develop→main" in lane ci.
+Work ONLY on files required for this task. Do NOT edit collaboration/**.
+Create and use branch: feat/T-505-integrate-release-pr-develop-main
+Keep changes under 300 lines if possible.
+Update/add tests to satisfy tasks/T-505/ACCEPTANCE.md.
+When done: open a PR titled "[T-505] Integrate release PR develop→main" and include validation steps.
+If blocked, write a single line under "## Blockers" in tasks/T-505/BRIEF.md.

--- a/tasks/T-505/ACCEPTANCE.md
+++ b/tasks/T-505/ACCEPTANCE.md
@@ -1,0 +1,4 @@
+# Acceptance
+- Release PR (existing #18 or new) passes all required checks
+- PR merged to `main` and deployment pipeline triggers successfully
+- Post-merge, `main` protection/required checks remain intact

--- a/tasks/T-505/BRIEF.md
+++ b/tasks/T-505/BRIEF.md
@@ -1,0 +1,15 @@
+# T-505: Integrate release PR develop→main
+Lane: ci
+Plan: 2025-09-04-stabilize-develop-release
+Baseline: develop
+
+## Scope
+Implement only what is necessary to satisfy ACCEPTANCE.md.
+
+## Deliverables
+- Code + tests
+- PR titled "[T-505] Integrate release PR develop→main"
+- PR body includes how you validated acceptance
+
+## Blockers
+(Write here if blocked; 1–2 lines)


### PR DESCRIPTION
# Acceptance — T-502: Make backend-tests green on 3.12 and 3.13

- backend-tests (3.12) job passes on a PR against `develop`.
- backend-tests (3.13) job passes on a PR against `develop`.
- Coverage XML and JUnit XML artifacts are uploaded by CI.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes in this release.

- Documentation
  - Introduced a clearer release plan with defined lanes and task dependencies.
  - Added acceptance briefs for backend tests (Python 3.12/3.13), frontend build/tests, CI gating, and release integration.
  - Drafted updates to branch model and PR policy to appear in README and CONTRIBUTING.

- Chores
  - Added task rule guidelines to standardise implementation workflow across CI, backend, frontend, and docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->