### PR TITLE
[T-503] Fix frontend build and unit tests

### DIFF
--- a/.cursor/rules/tasks/T-503.mdc
+++ b/.cursor/rules/tasks/T-503.mdc
@@ -1,0 +1,32 @@
+---
+description: Task T-503 — Fix frontend build/tests (auto-applied)
+globs:
+  - "collaboration/tasks/T-503/**"
+  - "frontend/src/**"
+  - "frontend/vitest.config.js"
+  - "frontend/vite.config.js"
+  - "frontend/eslint.config.js"
+---
+
+Context Reset: New subtask
+Task: T-503 — Fix frontend build and unit tests
+Lane: frontend
+Branch: feat/T-503-frontend-tests-build-green
+
+DoD:
+- Lint/build/test green in CI; no console errors
+- Changes minimal and scoped; no secrets/network
+- Critic review passes
+
+Acceptance:
+- `npm run lint` passes with no errors.
+- `npm run build` (Vite) succeeds with no errors.
+- `npm run test:ci` (Vitest) passes on CI.
+
+Changescope:
+- frontend/src/**
+- frontend/vitest.config.js
+- frontend/vite.config.js
+- frontend/eslint.config.js
+
+Output: code changes only; summarize what changed and next subtask.

--- a/collaboration/tasks/T-503/ACCEPTANCE.md
+++ b/collaboration/tasks/T-503/ACCEPTANCE.md
@@ -1,0 +1,6 @@
+# Acceptance — T-503: Fix frontend build and unit tests
+
+- `npm run lint` passes with no errors.
+- `npm run build` (Vite) succeeds with no errors.
+- `npm run test:ci` (Vitest) passes on CI.
+

--- a/collaboration/tasks/T-503/BRIEF.md
+++ b/collaboration/tasks/T-503/BRIEF.md
@@ -1,0 +1,15 @@
+# T-503: Fix frontend build and unit tests
+Lane: frontend
+Plan: 2025-09-04-stabilize-develop-release
+Baseline: develop
+
+## Scope
+Resolve FE lint/build/test failures; avoid network dependencies in tests.
+
+## Deliverables
+- Minimal changes in frontend/** to satisfy ACCEPTANCE.md.
+- PR titled "[T-503] Fix frontend build and unit tests".
+- PR body includes validation steps and any mocks added.
+
+## Blockers
+(none yet)


### PR DESCRIPTION
# Acceptance — T-503: Fix frontend build and unit tests

- `npm run lint` passes with no errors.
- `npm run build` (Vite) succeeds with no errors.
- `npm run test:ci` (Vitest) passes on CI.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added internal task and acceptance documents defining lint, build, and test criteria and commands, plus scope and deliverables for the related work.
- Chores
  - Introduced scoped automation for frontend-related checks to align CI with lint/build/test requirements.

No user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->