### PR TITLE
[T-504] Document branch model and PR policy

### DIFF
--- a/.cursor/rules/tasks/T-504.mdc
+++ b/.cursor/rules/tasks/T-504.mdc
@@ -1,0 +1,29 @@
+---
+description: Task T-504 — Docs branch model (auto-applied)
+globs:
+  - "collaboration/tasks/T-504/**"
+  - "CONTRIBUTING.md"
+  - "README.md"
+  - ".github/pull_request_template.md"
+---
+
+Context Reset: New subtask
+Task: T-504 — Document branch model and PR policy
+Lane: docs
+Branch: feat/T-504-docs-branch-model
+
+DoD:
+- Docs updated; no contradictions; critic review
+
+Acceptance:
+- CONTRIBUTING.md includes develop base, update branch, release flow.
+- README.md has "Branch Model" with link to CONTRIBUTING.
+- PR template includes base=develop, up-to-date, size/scope guard.
+- No docs instruct to target main.
+
+Changescope:
+- CONTRIBUTING.md
+- README.md
+- .github/pull_request_template.md
+
+Output: code changes only; summarize what changed and next subtask.

--- a/collaboration/tasks/T-504/ACCEPTANCE.md
+++ b/collaboration/tasks/T-504/ACCEPTANCE.md
@@ -1,0 +1,7 @@
+# Acceptance — T-504: Document branch model and PR policy
+
+- CONTRIBUTING.md includes: PR base=develop; Update branch before review; releases via develop→main.
+- README.md adds a short "Branch Model" section linking to CONTRIBUTING.
+- .github/pull_request_template.md checklist includes base=develop, up-to-date, size/scope guard.
+- No docs instruct to target `main`.
+

--- a/collaboration/tasks/T-504/BRIEF.md
+++ b/collaboration/tasks/T-504/BRIEF.md
@@ -1,0 +1,14 @@
+# T-504: Document branch model and PR policy
+Lane: docs
+Plan: 2025-09-04-stabilize-develop-release
+Baseline: develop
+
+## Scope
+Update docs and PR template to reflect develop-based workflow and release flow.
+
+## Deliverables
+- Doc updates per ACCEPTANCE.md.
+- PR titled "[T-504] Document branch model and PR policy".
+
+## Blockers
+(none yet)


### PR DESCRIPTION
# Acceptance — T-504: Document branch model and PR policy

- CONTRIBUTING.md includes: PR base=develop; Update branch before review; releases via develop→main.
- README.md adds a short "Branch Model" section linking to CONTRIBUTING.
- .github/pull_request_template.md checklist includes base=develop, up-to-date, size/scope guard.
- No docs instruct to target `main`.

