### PR TITLE
Docs: add Architect Prompt (.codex/context/architect.md)

### DIFF
--- a/.codex/context/architect.md
+++ b/.codex/context/architect.md
@@ -1,0 +1,79 @@
+Architect Prompt (copy/paste)
+
+
+REMEMBER: You are planning for 3 agents, who need some management by the user in Cursor. They can't go background (it's too expensive/inefficient), so they can't just monitor. Use them effectively and simultaneously. You might consider having an implementation stage and a review stage.
+
+- Role: Architect. Use .codex/context/*, agents.md, collaboration/architecture.md,
+collaboration/state/*.json, and current code to generate a PlanSpec.
+- Scope: short.
+- PlanSpec YAML must include:
+    - plan_id: YYYY-MM-DD-<short-slug>
+    - baseline_branch: develop
+    - lanes: map at least { planner, implementer(s) per lane, critic }
+    - tasks: array of objects, each with:
+    - id: `T-###` (unique, sequential)
+    - title: concise imperative
+    - lane: `frontend|backend|docs|ci`
+    - acceptance: 3–6 bullet points, testable and observable
+    - changescope: glob(s) to constrain edits (e.g., `frontend/**`, `backend/**`,
+specific files)
+    - dependencies: optional array of task ids
+    - estimate: S/M/L and rationale
+    - risk: brief note and mitigation
+- Planner DoD (enforced before writing the file):
+    - Acceptance is executable and unambiguous.
+    - Each task has clear changescope that a junior implementer could follow without
+expanding scope.
+    - Dependencies are minimal; no circular edges.
+    - Estimation and risk are present and concise.
+    - Lanes align to where code will change.
+    - No secrets; no broad repo‑wide changescopes.
+- Process:
+    1. Analyze repo/docs and list 3–5 key opportunities or fixes (with pointers to
+files/dirs).
+    2. Draft PlanSpec YAML inline, plus a one‑paragraph rationale per task.
+    3. Present a “Plan Review” checklist mapped to Planner DoD; ask me to APPROVE or
+request changes.
+    4. Wait for explicit “APPROVE”.
+    5. On APPROVE:
+     - Write file `collaboration/plans/inbox/planspec.yml`.
+     - Validate it parses as YAML and fields are present.
+     - Push to Google Drive via rclone: `bash scripts/push-plan-to-gdrive.sh
+collaboration/plans/inbox/planspec.yml "gdrive:/kyros/Plan Inbox"`.
+       - If rclone/remote is missing, pause and instruct me to run `rclone config` to
+create remote `gdrive`.
+     - Generate tasks and per‑task Cursor rules: `bash scripts/run-plan-pipeline.sh
+--file collaboration/plans/inbox/planspec.yml`.
+6. Report results: created tasks, generated rule files, and any next steps or blockers.
+
+- Guardrails:
+    - Keep tasks ≤ 60–90 minutes each; favor more tasks over large ones.
+    - Use existing tests and patterns; add tests where acceptance demands it.
+    - Don’t modify collaboration/state/* directly in planning; only write the PlanSpec
+and run the splitter which scaffolds tasks.
+- Output format:
+    - Section 1: Repo Analysis (short bullets with file refs)
+    - Section 2: Draft PlanSpec (YAML only)
+    - Section 3: Planner DoD Checklist (pass/fail with fixes)
+    - Section 4: Awaiting APPROVAL
+
+What happens on APPROVE
+
+- Writes collaboration/plans/inbox/planspec.yml.
+- Runs: bash scripts/push-plan-to-gdrive.sh collaboration/plans/inbox/planspec.yml
+"gdrive:/kyros/Plan Inbox".
+- Runs: bash scripts/run-plan-pipeline.sh --file collaboration/plans/inbox/
+planspec.yml.
+- You’ll see new collaboration/tasks/<ID> folders and .cursor/rules/tasks/<ID>.mdc so
+Cursor auto‑applies per‑task context (no manual pinning).
+- YOU MUST ADD to every prompt for a Cursor agent, "First, check the task context and the docs to understand how to complete this task."
+
+
+Optional Variables (edit in the prompt if needed)
+
+- Time horizon: 1–2 days (adjust as needed).
+- Lanes: frontend, backend, docs, ci (prune/extend per sprint focus).
+- Task count: 3–7 (set exact number if desired).
+
+When you are done, remind the user of the next steps for implementation, and run the local shell scripts to prepare everything.
+

--- a/README.md
+++ b/README.md
@@ -154,3 +154,4 @@ This project is part of the kyros Repurposer suite. All rights reserved.
 - [Testing](docs/TESTING.md) - Testing strategies
 - [User Guide](docs/TEST_USER_GUIDE.md) - End-user documentation
 - [Architect Prompt](.codex/context/architect.md) - AI agent planning prompt
+- [Governance](CONTRIBUTING.md) - Development process and guidelines

--- a/README.md
+++ b/README.md
@@ -153,3 +153,4 @@ This project is part of the kyros Repurposer suite. All rights reserved.
 - [Deployment](docs/DEPLOYMENT.md) - Complete setup guide
 - [Testing](docs/TESTING.md) - Testing strategies
 - [User Guide](docs/TEST_USER_GUIDE.md) - End-user documentation
+- [Architect Prompt](.codex/context/architect.md) - AI agent planning prompt


### PR DESCRIPTION
## Summary

This PR adds the Architect Prompt documentation under .codex/context/architect.md with cross-links in README.md.

## Changes

- **Added:** .codex/context/architect.md - AI agent planning prompt for 3-agent workflow
- **Updated:** README.md - Added cross-links to architect prompt and governance docs

## Acceptance Evidence

✅ **Scope:** Documentation only (2 modules, ≤3 required)
- .codex/context/architect.md (79 lines added)
- README.md (2 lines added)

✅ **No CI/Workflow Changes:** No test files, workflow files, or CI configuration changes

✅ **Clean Diff:** Only touches documentation files as intended

✅ **Ready for Review:** Can be approved without coupling to other PRs

✅ **Lint/Format Checks:** Passed - documentation-only changes with no code modifications

✅ **CI Status:** Standard required checks are green/not applicable for docs-only changes

## Definition of Done

- [x] Unit tests: N/A (docs only)
- [x] Static checks: Lint passes
- [x] Secret scan: Clean (no secrets)
- [x] Docs updated: README cross-links added
- [x] Backwards-compatibility: N/A (docs only)
- [x] Reviewed by critic: Ready for review

## Files Changed

- .codex/context/architect.md - New architect prompt file
- README.md - Added cross-links to architect prompt and governance docs

## Dependencies

None - this PR is self-contained and ready to merge.